### PR TITLE
Add GuildVoiceStates intent to client configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ const client = new Client({
         GatewayIntentBits.Guilds,
         GatewayIntentBits.GuildMessages,
         GatewayIntentBits.MessageContent,
-		GatewayIntentBits.GuildMembers
+		GatewayIntentBits.GuildMembers,
+		GatewayIntentBits.GuildVoiceStates
     ]
 });
 


### PR DESCRIPTION
Fixed that users who joined the from channel shortly before the move command was invoked weren't moved